### PR TITLE
update sidebarsearchcon

### DIFF
--- a/src/Beastiepedia/Filter.tsx
+++ b/src/Beastiepedia/Filter.tsx
@@ -77,6 +77,7 @@ export default function Filter({
     <div
       className={styles.filterButton}
       role="button"
+      title="Sort by Filters"
       tabIndex={0}
       onClick={() => setOpen(true)}
     >

--- a/src/Beastiepedia/Sidebar.module.css
+++ b/src/Beastiepedia/Sidebar.module.css
@@ -27,6 +27,14 @@
 
 .sidebarsearch {
   flex-grow: 1;
+  flex-shrink: 1;
+  min-width: 20px;
+}
+
+.sidebarselect {
+  flex-grow: 0.5;
+  flex-shrink: 1;
+  min-width: 0;
 }
 
 .gridimage {

--- a/src/Beastiepedia/Sidebar.tsx
+++ b/src/Beastiepedia/Sidebar.tsx
@@ -84,7 +84,10 @@ export default function Sidebar(props: Props): React.ReactElement {
           className={styles.sidebarsearch}
           onChange={(event) => setSearch(event.currentTarget.value)}
         />
-        <select onChange={(event) => setSort(event.currentTarget.value)}>
+        <select 
+          onChange={(event) => setSort(event.currentTarget.value)}
+          className={styles.sidebarselect}
+        >
           <option value="number">Number</option>
           <option value="name">Name</option>
           <option value="total">Stat Total</option>


### PR DESCRIPTION
![{F572B989-6787-46B6-84EB-2BFBEE7A98AD}](https://github.com/user-attachments/assets/28b2dbba-3f83-437a-9c88-f23b29ba9541)
![{FB1F5922-D4A4-442F-874F-C6ECA033FD93}](https://github.com/user-attachments/assets/4d9aa528-0471-4c6d-bd79-92796fcd73af)
This fixes sidebarsearchcon content overflowing under certain viewport ratio.   

![{FA133C66-3739-4822-AA0A-0BB98F020C74}](https://github.com/user-attachments/assets/41042966-22c7-427a-97d7-48c0bde4eac6)
This PR also adds a missing tooltip for filter toggle button.